### PR TITLE
feat: return early if product or key is blank

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,13 @@ var client = &http.Client{
 }
 
 func doCheck(api, product, key string) error {
+	switch "" {
+	case product:
+		return fmt.Errorf("license: failed check license: product is blank")
+	case key:
+		return fmt.Errorf("license: failed check license: license key is blank")
+	}
+
 	resp, err := client.PostForm(api,
 		url.Values{
 			"product_permalink": {product},


### PR DESCRIPTION
Adds a quick guard in `doCheck` to return early if either `product` or `key` is blank. This avoids an API call to GumRoad for data that is certain to be invalid.