### PR TITLE
refactor!: update Gumroad API request param

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ package main
 import "github.com/caarlos0/go-gumroad"
 
 func check(key string) error {
-	prod, err := gumroad.NewProduct("my-product-permalink")
+	prod, err := gumroad.NewProduct("my_product_id")
 	if err != nil {
 		return err
 	}
+
 	return prod.Verify(key)
 }
 ```

--- a/main.go
+++ b/main.go
@@ -17,16 +17,18 @@ import (
 
 // Product represents a product in Gumroad on which license keys can be verified.
 type Product struct {
-	API     string
+	ID  string
+	API string
+	// Deprecated: `product_permalink` parameter is deprecated.
 	Product string
 	Client  *http.Client
 }
 
 // NewProduct returns a new GumroadProduct with reasonable defaults.
-func NewProduct(product string) (Product, error) {
-	// early return if product permalink is empty
-	if product == "" {
-		return Product{}, errors.New("license: product permalink cannot be empty")
+func NewProduct(ID string) (Product, error) {
+	// early return if product ID is empty
+	if ID == "" {
+		return Product{}, errors.New("license: product ID cannot be empty")
 	}
 
 	// Capture the root certificate pool at build time. `x509.SystemCertPool` is guaranteed not to return
@@ -52,8 +54,8 @@ func NewProduct(product string) (Product, error) {
 	}
 
 	return Product{
-		API:     "https://api.gumroad.com/v2/licenses/verify",
-		Product: product,
+		API: "https://api.gumroad.com/v2/licenses/verify",
+		ID:  ID,
 		Client: &http.Client{
 			Timeout:   time.Minute,
 			Transport: transport,
@@ -68,8 +70,8 @@ func (gp Product) VerifyWithContext(ctx context.Context, key string) error {
 		return errors.New("license: license key cannot be empty")
 	}
 	req, err := http.NewRequestWithContext(ctx, "POST", gp.API, strings.NewReader(url.Values{
-		"product_permalink": {gp.Product},
-		"license_key":       {key},
+		"product_id":  {gp.ID},
+		"license_key": {key},
 	}.Encode()))
 	if err != nil {
 		return err

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ func TestIntegrationInvalidLicense(t *testing.T) {
 
 func TestEmptyProduct(t *testing.T) {
 	t.Parallel()
-	expected := "license: product permalink cannot be empty"
+	expected := "license: product ID cannot be empty"
 	_, err := NewProduct("")
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected %q, got %v", expected, err)
@@ -51,7 +51,7 @@ func TestErrors(t *testing.T) {
 			}))
 			t.Cleanup(ts.Close)
 
-			p, err := NewProduct(tt.product)
+			p, err := NewProduct(tt.id)
 			if err != nil {
 				t.Errorf("unexpected error %v", err)
 			}
@@ -189,12 +189,12 @@ func BenchmarkErrors(b *testing.B) {
 }
 
 var testCases = map[string]struct {
-	product, key string
-	resp         GumroadResponse
-	eeer         string
+	id, key string
+	resp    GumroadResponse
+	eeer    string
 }{
 	"invalid license": {
-		product: "product", key: "key",
+		id: "product_id", key: "key",
 		resp: GumroadResponse{
 			Success: false,
 			Message: "some error",
@@ -202,7 +202,7 @@ var testCases = map[string]struct {
 		eeer: "license: invalid license: some error",
 	},
 	"refunded": {
-		product: "product", key: "key",
+		id: "product_id", key: "key",
 		resp: GumroadResponse{
 			Success: true,
 			Purchase: Purchase{
@@ -212,7 +212,7 @@ var testCases = map[string]struct {
 		eeer: "license: license was refunded and is now invalid",
 	},
 	"canceled": {
-		product: "product", key: "key",
+		id: "product_id", key: "key",
 		resp: GumroadResponse{
 			Success: true,
 			Purchase: Purchase{
@@ -222,7 +222,7 @@ var testCases = map[string]struct {
 		eeer: "license: subscription was canceled, license is now invalid",
 	},
 	"failed": {
-		product: "product", key: "key",
+		id: "product_id", key: "key",
 		resp: GumroadResponse{
 			Success: true,
 			Purchase: Purchase{
@@ -233,7 +233,7 @@ var testCases = map[string]struct {
 		eeer: "license: failed to renew subscription, please check at https://gumroad.com/subscriptions/xyz/manage",
 	},
 	"valid": {
-		product: "product", key: "key",
+		id: "product_id", key: "key",
 		resp: GumroadResponse{
 			Success: true,
 			Purchase: Purchase{
@@ -243,7 +243,7 @@ var testCases = map[string]struct {
 		},
 	},
 	"blank key": {
-		product: "product", key: "",
+		id: "product_id", key: "",
 		eeer: "license: license key cannot be empty",
 	},
 }


### PR DESCRIPTION
This commit introduces breaking changes to the `Product` struct & `NewProduct` func:

* Deprecated the **Product** field in the `Product` struct.
* Added **ID** field in the `Product` struct as replacement for **Product** field.
* Updated the `NewProduct` function to accept & use product ID instead of the product permalink[^1].
* Modified the `VerifyWithContext` method to use **product_id**[^1] parameter instead of **product_permalink** in the API req body.

Fix #33

[^1]: https://help.gumroad.com/article/76-license-keys#verification
