### PR TITLE
feat!: product_id, more fields, validate always use context, more validations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,30 +12,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: CI
-        run: make setup ci
-      - name: Upload coverage
-        uses: codecov/codecov-action@v5
+          go-version: stable
+      - run: make setup ci
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v6
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: latest

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/caarlos0/go-gumroad
+module github.com/caarlos0/go-gumroad/v2
 
 go 1.23

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/caarlos0/go-gumroad
 
-go 1.16
+go 1.23

--- a/main.go
+++ b/main.go
@@ -144,15 +144,53 @@ type GumroadResponse struct {
 
 // Purchase is Purchase from the GumRoad API
 type Purchase struct {
-	Email                   string    `json:"email"`
-	Refunded                bool      `json:"refunded"`
-	SaleTimestamp           time.Time `json:"sale_timestamp"`
-	SubscriptionCancelledAt time.Time `json:"subscription_cancelled_at"`
-	SubscriptionFailedAt    time.Time `json:"subscription_failed_at"`
-	SubscriptionID          string    `json:"subscription_id"`
 	SellerID                string    `json:"seller_id"`
 	ProductID               string    `json:"product_id"`
 	ProductName             string    `json:"product_name"`
 	Permalink               string    `json:"permalink"`
 	ProductPermalink        string    `json:"product_permalink"`
+	ShortProductID          string    `json:"short_product_id"`
+	Email                   string    `json:"email"`
+	Price                   int       `json:"price"`
+	GumroadFee              int       `json:"gumroad_fee"`
+	Currency                string    `json:"currency"`
+	Quantity                int       `json:"quantity"`
+	DiscoverFeeCharged      bool      `json:"discover_fee_charged"`
+	CanContact              bool      `json:"can_contact"`
+	Referrer                string    `json:"referrer"`
+	Card                    Card      `json:"card"`
+	OrderNumber             int       `json:"order_number"`
+	SaleID                  string    `json:"sale_id"`
+	SaleTimestamp           time.Time `json:"sale_timestamp"`
+	SubscriptionID          string    `json:"subscription_id"`
+	Variants                string    `json:"variants"`
+	OfferCode               OfferCode `json:"offer_code"`
+	LicenseKey              string    `json:"license_key"`
+	IsMultiseatLicense      bool      `json:"is_multiseat_license"`
+	IPCountry               string    `json:"ip_country"`
+	Recurrence              string    `json:"recurrence"`
+	IsGiftReceiverPurchase  bool      `json:"is_gift_receiver_purchase"`
+	Refunded                bool      `json:"refunded"`
+	Disputed                bool      `json:"disputed"`
+	DisputeWon              bool      `json:"dispute_won"`
+	ID                      string    `json:"id"`
+	CreatedAt               string    `json:"created_at"`
+	CustomFields            []any     `json:"custom_fields"`
+	SubscriptionEndedAt     *string   `json:"subscription_ended_at"`
+	SubscriptionCancelledAt time.Time `json:"subscription_cancelled_at"`
+	SubscriptionFailedAt    time.Time `json:"subscription_failed_at"`
+}
+
+type Card struct {
+	Visual      string `json:"visual"`
+	Type        string `json:"type"`
+	Bin         string `json:"bin"`
+	ExpiryMonth string `json:"expiry_month"`
+	ExpiryYear  string `json:"expiry_year"`
+}
+
+type OfferCode struct {
+	Code               string `json:"code"`
+	DisplayedAmountOff string `json:"displayed_amount_off"`
+	Name               string `json:"name"`
 }

--- a/main.go
+++ b/main.go
@@ -124,13 +124,16 @@ func (gp Product) doVerify(ctx context.Context, key string, try int) error {
 	}
 
 	if gumroad.Purchase.ProductID != gp.ProductID {
-		return fmt.Errorf("license: unexpected product ID")
+		return fmt.Errorf("license: invalid product ID")
+	}
+
+	if gumroad.Purchase.LicenseKey != key {
+		return fmt.Errorf("license: invalid license")
 	}
 
 	if gp.Validate != nil {
 		return gp.Validate(gumroad)
 	}
-
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ type Purchase struct {
 	ID                      string    `json:"id"`
 	CreatedAt               string    `json:"created_at"`
 	CustomFields            []any     `json:"custom_fields"`
-	SubscriptionEndedAt     *string   `json:"subscription_ended_at"`
+	SubscriptionEndedAt     time.Time `json:"subscription_ended_at"`
 	SubscriptionCancelledAt time.Time `json:"subscription_cancelled_at"`
 	SubscriptionFailedAt    time.Time `json:"subscription_failed_at"`
 }

--- a/main_test.go
+++ b/main_test.go
@@ -322,7 +322,7 @@ var testCases = map[string]struct {
 		product: "product", key: "",
 		eeer: "license: license key cannot be empty",
 	},
-	"product id missmatch": {
+	"product id mismatch": {
 		product: "product", key: "key",
 		eeer: "license: invalid product ID",
 		resp: GumroadResponse{
@@ -348,7 +348,7 @@ var testCases = map[string]struct {
 			},
 		},
 	},
-	"seller id missmatch": {
+	"seller id mismatch": {
 		product: "product", key: "key",
 		eeer: "invalid seller id",
 		resp: GumroadResponse{

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package gumroad
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,7 +24,7 @@ func TestIntegrationInvalidLicense(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-	err = p.Verify("nope")
+	err = p.Verify(context.Background(), "nope")
 	if err == nil || err.Error() != expected {
 		t.Errorf("expected an error %q, got %v", expected, err)
 	}
@@ -31,7 +32,7 @@ func TestIntegrationInvalidLicense(t *testing.T) {
 
 func TestEmptyProduct(t *testing.T) {
 	t.Parallel()
-	expected := "license: product permalink cannot be empty"
+	expected := "license: product ID cannot be empty"
 	_, err := NewProduct("")
 	if err == nil || err.Error() != expected {
 		t.Fatalf("expected %q, got %v", expected, err)
@@ -58,7 +59,7 @@ func TestErrors(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 			}
 			p.API = ts.URL
-			err = p.Verify(tt.key)
+			err = p.Verify(context.Background(), tt.key)
 
 			if tt.eeer == "" {
 				if err != nil {
@@ -88,6 +89,7 @@ func Test5xx(t *testing.T) {
 				Purchase: Purchase{
 					SaleTimestamp: time.Now(),
 					Email:         "foo@example.com",
+					ProductID:     "product",
 				},
 			})
 			_, _ = w.Write(bts)
@@ -105,7 +107,7 @@ func Test5xx(t *testing.T) {
 	p.API = server.URL
 	p.Client = server.Client()
 
-	err = p.Verify(license)
+	err = p.Verify(context.Background(), license)
 	if err != nil {
 		t.Fatal("expected no error")
 	}
@@ -116,7 +118,9 @@ func Test5xx(t *testing.T) {
 
 func TestMITM(t *testing.T) {
 	t.Parallel()
-	license := "DEADBEEF-CAFE1234-5678DEAD-BEEFCAFE"
+	const license = "DEADBEEF-CAFE1234-5678DEAD-BEEFCAFE"
+	const productID = "product-id-1234"
+	const sellerID = "seller-id-1234"
 
 	// server will stand in for GumRoad, and assume that any license it sees is invalid
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -136,6 +140,10 @@ func TestMITM(t *testing.T) {
 
 		resp := GumroadResponse{
 			Success: data.Get("license_key") == license,
+			Purchase: Purchase{
+				ProductID: productID,
+				SellerID:  sellerID,
+			},
 		}
 
 		switch resp.Success {
@@ -152,20 +160,26 @@ func TestMITM(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	p, err := NewProduct("product")
+	p, err := NewProduct(productID)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
+	}
+	p.Validate = func(gr GumroadResponse) error {
+		if gr.Purchase.SellerID != sellerID {
+			return fmt.Errorf("invalid seller id")
+		}
+		return nil
 	}
 	p.API = server.URL
 	// Save the default client, which does not trust the test TLS certificate
 	defaultClient := p.Client
 	// The server.Client() is configured to trust the test TLS certificate
 	p.Client = server.Client()
-	err = p.Verify("fake-key")
+	err = p.Verify(context.Background(), "fake-key")
 	if !strings.Contains(err.Error(), "invalid license") {
 		t.Fatalf("expected error to indicate that the license is invalid, but got: %s", err)
 	}
-	if err := p.Verify(license); err != nil {
+	if err := p.Verify(context.Background(), license); err != nil {
 		t.Fatalf("unexpected error when checking valid key: %s", err)
 	}
 
@@ -173,7 +187,13 @@ func TestMITM(t *testing.T) {
 	mitm := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Header().Add("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(GumroadResponse{Success: true}); err != nil {
+		if err := json.NewEncoder(w).Encode(GumroadResponse{
+			Success: true,
+			Purchase: Purchase{
+				ProductID: productID,
+				SellerID:  sellerID,
+			},
+		}); err != nil {
 			t.Errorf("error encoding response: %s", err)
 		}
 	}))
@@ -184,7 +204,7 @@ func TestMITM(t *testing.T) {
 	p.API = mitm.URL
 	// Set the client back to the default, which doesn't trust the test certificate used by mitm
 	p.Client = defaultClient
-	err = p.Verify(license)
+	err = p.Verify(context.Background(), license)
 	if err == nil {
 		t.Fatalf("MITM was successful")
 	} else if !strings.Contains(err.Error(), "failed check license") {
@@ -201,11 +221,11 @@ func TestMITM(t *testing.T) {
 
 	p.API = proxyServer.URL
 	p.Client = proxyServer.Client()
-	err = p.Verify("fake-key")
+	err = p.Verify(context.Background(), "fake-key")
 	if !strings.Contains(err.Error(), "invalid license") {
 		t.Fatalf("expected error to indicate that the license is invalid, but got: %s", err)
 	}
-	if err := p.Verify(license); err != nil {
+	if err := p.Verify(context.Background(), license); err != nil {
 		t.Fatalf("unexpected error when checking valid key: %s", err)
 	}
 }
@@ -225,7 +245,7 @@ func BenchmarkErrors(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				p, _ := NewProduct("product")
 				p.API = ts.URL
-				_ = p.Verify("key")
+				_ = p.Verify(context.Background(), "key")
 			}
 		})
 	}
@@ -282,6 +302,7 @@ var testCases = map[string]struct {
 			Purchase: Purchase{
 				SaleTimestamp: time.Now(),
 				Email:         "foo@example.com",
+				ProductID:     "product",
 			},
 		},
 	},


### PR DESCRIPTION
BREAKING CHANGE!

- NewProduct now takes a product id
- More fields were added to the GumroadResponse (all of them in fact)
- You can now set more validations with product.Validate=func()
- Go version updated